### PR TITLE
Add basic build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11" ]
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Pythin ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install dependencies
+        run: |
+          sudo apt install python3-tk -y
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
+      
+      - name: Test
+        run: |
+          pytest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build](https://github.com/falk-werner/note.py/actions/workflows/build.yml/badge.svg)](https://github.com/falk-werner/note.py/actions/workflows/build.yml)
+
 # note.py
 
 [note.py](https://github.com/falk-werner/note.py) is yet another note taking app. It is aimed to be minimalistic and is shipped as a single python file.


### PR DESCRIPTION
This pull requiest adds a basic workflow to test the script. There are only very basic tests yet, but this might be improved in future. In it's current state, the workflow verifies that alle requirements are provided and the script can be loaded in some selected python versions.

_Note that Python 3.9 or newer is required, since we use `os.waitstatus_to_exitcode`, which is not available in older versions._