### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     
     steps:
       - uses: actions/checkout@v3

--- a/test_waitstatus_to_exitcode.py
+++ b/test_waitstatus_to_exitcode.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 Falk Werner
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from note import waitstatus_to_exitcode
+import os
+
+def test_affirmative_exitcode():
+    status = os.system('true')
+    exit_code = waitstatus_to_exitcode(status)
+    assert exit_code == 0
+
+def test_non_affirmative_exitcode():
+    status = os.system('false')
+    exit_code = waitstatus_to_exitcode(status)
+    assert exit_code != 0


### PR DESCRIPTION
Python 3.8 should be supported, since it is the default version for Ubuntu 20.04 (focal).