### PR TITLE
Allow custom screenshot command

### DIFF
--- a/note.py
+++ b/note.py
@@ -63,10 +63,11 @@ class Persistence:
         self.__notespath = os.path.join(self.__basepath, "notes")
         self.__mkdir(self.__notespath)
         self.__css = self.__load_css()
-        if which("spectacle") is not None:
-            self.screen_tool = "spectacle -rbn -o"
-        else:
-            self.screen_tool = "gnome-screenshot -a -f"
+        self.__screenshot_command = self.__find_screenshot_command()
+
+    def __find_screenshot_command(self):
+        return "spectacle -rbn -o \"{filename}\"" if which("spectacle") is not None \
+            else "gnome-screenshot -a -f \"{filename}\""
 
     def __load_css(self):
         css_filename = os.path.join(self.__basepath, "style.css")
@@ -131,7 +132,7 @@ class Persistence:
         """Takes a screenshot and returns it's filename."""
         filename = "screenshot_" + str(uuid.uuid4()) + ".png"
         full_filename = os.path.join(self.note_path(name), filename)
-        status = os.system(f'{self.screen_tool} "{full_filename}"')
+        status = os.system(self.__screenshot_command.format(filename=full_filename))
         exit_code = os.waitstatus_to_exitcode(status)
         return filename if 0 == exit_code else None
 

--- a/note.py
+++ b/note.py
@@ -203,7 +203,7 @@ class Persistence:
         filename = "screenshot_" + str(uuid.uuid4()) + ".png"
         full_filename = os.path.join(self.note_path(name), filename)
         status = os.system(self.__screenshot_command.format(filename=full_filename))
-        exit_code = os.waitstatus_to_exitcode(status)
+        exit_code = waitstatus_to_exitcode(status)
         return filename if 0 == exit_code else None
 
     def css(self):

--- a/note.py
+++ b/note.py
@@ -15,6 +15,7 @@ import webbrowser
 import base64
 import uuid
 import shutil
+from shutil import which
 from pathlib import Path
 from tkinter import scrolledtext
 from tkinter import ttk
@@ -62,6 +63,10 @@ class Persistence:
         self.__notespath = os.path.join(self.__basepath, "notes")
         self.__mkdir(self.__notespath)
         self.__css = self.__load_css()
+        if which("spectacle") is not None:
+            self.screen_tool = "spectacle -rbn -o"
+        else:
+            self.screen_tool = "gnome-screenshot -a -f"
 
     def __load_css(self):
         css_filename = os.path.join(self.__basepath, "style.css")
@@ -126,7 +131,7 @@ class Persistence:
         """Takes a screenshot and returns it's filename."""
         filename = "screenshot_" + str(uuid.uuid4()) + ".png"
         full_filename = os.path.join(self.note_path(name), filename)
-        status = os.system(f'gnome-screenshot -a -f "{full_filename}"')
+        status = os.system(f'{self.screen_tool} "{full_filename}"')
         exit_code = os.waitstatus_to_exitcode(status)
         return filename if 0 == exit_code else None
 


### PR DESCRIPTION
This pull request makes it possible to specify a custom screenshot command.
There are two different way to do this:

1. note.py searches itself for a valid screenshot command
2. a user can specify a custom command in the {home}/.notepy config file

@hmlampe: note that this pull request also introduces a mechanism to save the config file, which may be useful for later features, e.g. saving the geometry on shutdown.