### PR TITLE
Set focus on edit

### DIFF
--- a/note.py
+++ b/note.py
@@ -581,6 +581,8 @@ class NoteFrame(ttk.Frame):
         tab = self.notebook.index(self.notebook.select())
         new_tab = 0 if tab == 1 else 1
         self.notebook.select(new_tab)
+        if new_tab == 1:
+            self.text.focus_set()
 
 
 class App:


### PR DESCRIPTION
When you switch to the Editing tab with the accelerator, set the focus on the text box so you can start editing without having to switch to the mouse