### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: $$ {{ github.ref }}
+          release_name: ${{ githib.ref }}
+          body_path: ${{ github.workspace }}/changelog.md
+          draft: true
+          prerelease: false
+
+      - name: Upload note.py
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./note.py
+          asset_name: note.py
+          asset_content_type: text/x-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: $$ {{ github.ref }}
-          release_name: ${{ githib.ref }}
+          release_name: ${{ github.ref }}
           body_path: ${{ github.workspace }}/changelog.md
           draft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: $$ {{ github.ref }}
+          tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body_path: ${{ github.workspace }}/changelog.md
           draft: true


### PR DESCRIPTION
This pull requests adds a release workflow, wich adds a draft release whenever a tag is created.
A draft release is created so it can be checked before actual release.

The release notes are taken from `changelog.md`.
The tagged version of `note.py` is added as release artifact.