### PR TITLE
Remove Python 3.8 compatibility

### DIFF
--- a/note.py
+++ b/note.py
@@ -77,30 +77,6 @@ p code {
 CONFIG_FILE = ".notepy.yml"
 
 #-------------------------------------------
-# Shims
-#-------------------------------------------
-
-def shim_waitstatus_to_exitcode(status):
-    """Transforms waitstatus to exitcode without Python 3.9 features
-        (see https://bugs.python.org/issue40094 for details)
-
-        :param status: status code as returned by os.system
-        :type status: int
-
-        :return: exit code
-        :rtype: int
-    """
-    if os.WIFSIGNALED(status):
-        return -os.WTERMSIG(status)
-    if os.WIFEXITED(status):
-        return os.WEXITSTATUS(status)
-    if os.WIFSTOPPED(status):
-        return -os.WSTOPSIG(status)
-    return -1
-
-waitstatus_to_exitcode = getattr(os, 'waitstatus_to_exitcode', shim_waitstatus_to_exitcode)
-
-#-------------------------------------------
 # Persistence
 #-------------------------------------------
 
@@ -354,7 +330,7 @@ class Persistence:
         full_filename = os.path.join(self.note_path(name), filename)
         if platform.system() != "Windows":
             status = os.system(self.__screenshot_command.format(filename=full_filename))
-            exit_code = waitstatus_to_exitcode(status)
+            exit_code = os.waitstatus_to_exitcode(status)
         else:
             screenshot = ImageGrab.grab()
             screenshot.save(full_filename)

--- a/test_waitstatus_to_exitcode.py
+++ b/test_waitstatus_to_exitcode.py
@@ -6,18 +6,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from note import waitstatus_to_exitcode
 import os
 import pytest
 
 @pytest.mark.skipif(os.name=='nt', reason="Don't run on windows")
 def test_affirmative_exitcode():
     status = os.system('true')
-    exit_code = waitstatus_to_exitcode(status)
+    exit_code = os.waitstatus_to_exitcode(status)
     assert exit_code == 0
 
 @pytest.mark.skipif(os.name=='nt', reason="Don't run on windows")
 def test_non_affirmative_exitcode():
     status = os.system('false')
-    exit_code = waitstatus_to_exitcode(status)
+    exit_code = os.waitstatus_to_exitcode(status)
     assert exit_code != 0


### PR DESCRIPTION
This pull request drops Python 3.8 support by removing the shim for `waitstatus_to_exitcode` which is introduced in Python 3.9.
I don't think we are forced to support more than 4 Python versions. Note that official support for Python 3.8 is continued until [October 2024](https://www.python.org/downloads/).