### PR TITLE
Fix: Allow special charaters in node titles

### DIFF
--- a/note.py
+++ b/note.py
@@ -28,6 +28,7 @@ from PIL import ImageFont, ImageDraw, Image, ImageTk, ImageGrab
 from tkinterweb import HtmlFrame
 import cmarkgfm
 from cmarkgfm.cmark import Options as cmarkgfmOptions
+import urllib
 import yaml
 
 #-------------------------------------------
@@ -95,6 +96,12 @@ waitstatus_to_exitcode = getattr(os, 'waitstatus_to_exitcode', shim_waitstatus_t
 # Persistence
 #-------------------------------------------
 
+def quote(value):
+    return value.translate(str.maketrans({
+        "<":"%3C", ">": "%3E", ":": "%3A", "\"": "%22",
+        "/": "%2F", "\\":"%5C", "|": "%7C", "?": "%3F",
+        "*": "%2A", "%": "%25"}))
+ 
 # pylint: disable-next=too-many-instance-attributes
 class Persistence:
     """Persistence handling.
@@ -181,10 +188,10 @@ class Persistence:
             os.mkdir(path)
 
     def __note_filename(self, name):
-        return os.path.join(self.__notespath, name, "README.md")
+        return os.path.join(self.note_path(name), "README.md")
 
     def __note_tags_filename(self, name):
-        return os.path.join(self.__notespath, name, "tags.txt")
+        return os.path.join(self.note_path(name), "tags.txt")
 
     def geometry(self, geometry=None):
         """
@@ -228,7 +235,7 @@ class Persistence:
         :return: Path of directory that conatins the nore.
         :rtype: str
         """
-        return os.path.join(self.__notespath, name)
+        return os.path.join(self.__notespath, quote(name))
 
     def list_notes(self):
         """Returns a list of all notes.
@@ -238,9 +245,10 @@ class Persistence:
         """
         notes = []
         for name in os.listdir(self.__notespath):
-            notefile = self.__note_filename(name)
+            display_name = urllib.parse.unquote(name)
+            notefile = self.__note_filename(display_name)
             if os.path.isfile(notefile):
-                notes.append(name)
+                notes.append(display_name)
         return notes
 
     def read_note(self, name):

--- a/note.py
+++ b/note.py
@@ -18,6 +18,7 @@ import webbrowser
 import base64
 import uuid
 import shutil
+import urllib
 from shutil import which
 from pathlib import Path
 from tkinter import scrolledtext
@@ -28,7 +29,6 @@ from PIL import ImageFont, ImageDraw, Image, ImageTk, ImageGrab
 from tkinterweb import HtmlFrame
 import cmarkgfm
 from cmarkgfm.cmark import Options as cmarkgfmOptions
-import urllib
 import yaml
 
 #-------------------------------------------
@@ -97,11 +97,15 @@ waitstatus_to_exitcode = getattr(os, 'waitstatus_to_exitcode', shim_waitstatus_t
 #-------------------------------------------
 
 def quote(value):
+    """Quotes special characters that are not allowed in file names.
+    
+    Special characters are URL encoded.
+    """
     return value.translate(str.maketrans({
         "<":"%3C", ">": "%3E", ":": "%3A", "\"": "%22",
         "/": "%2F", "\\":"%5C", "|": "%7C", "?": "%3F",
         "*": "%2A", "%": "%25"}))
- 
+
 # pylint: disable-next=too-many-instance-attributes
 class Persistence:
     """Persistence handling.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tkinter-tooltip>=2.1.0
 tkinterweb>=3.23.1
 ttkthemes>=3.2.2
 PyYAML>=6.0.1
+urllib3>=2.0.7

--- a/test_persistence.py
+++ b/test_persistence.py
@@ -274,6 +274,23 @@ def test_create_note():
     check_note(Persistence(config_file), title, contents, ["new", "note"])
 
 
+def test_create_note_special_char():
+    """Checks if a new note can be created with some special characters."""
+
+    config_file = fs.write_configfile()
+    persistence = Persistence(config_file)
+    title = "new_note /!<>:\ \\ | ?*%"
+    contents = "# New Note\n\nThis is a new note."
+    persistence.write_note(title, contents)
+    persistence.write_tags(title, ["new", "note"])
+
+    check_note(persistence, title, contents, ["new", "note"])
+
+    # Check also against fresh persistence to make
+    # sure everything is written to file system.
+    check_note(Persistence(config_file), title, contents, ["new", "note"])
+
+
 def test_modify_existing_note():
     """Checks if a note can be moified."""
 


### PR DESCRIPTION
Instead of restricting the user to allowed file names, we should also allow special characters in note titles.
I think, the most restrictions come from windows file systems (see below).

I had two possible solutions in mind:
- use URL encoding for node titles
- save note titles somewhere else

The quickest solution and the one which is picked here is to use URL encoding. However, we do not encode every character but only special characters which are prohibited in file names (<, >, :, ", /, \, |, ?, *) and the escape character (%). For decoding, a full URL decode is used. This is safe as long as all notes are created by `note.py` or any other tool which encodes file names the same way.

Another solution will be to store the full title somewhere else in the note's directory. Maybe some `metadata.yml`. We should try to keep the directory name an title in sync, but we are not forced to. This solution will take more effort but the `metadata.yml` might come in handy later, when other meta data should be stored (e.g. tags).

@hmlampe: Please let me know, which solution you prefer.

References:
- [Windows file Naming rules](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file)