### PR TITLE
add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.venv
 /dist
 /note.py_gui.egg-info
+/venv


### PR DESCRIPTION
venv is used to store python virtual ennvironment